### PR TITLE
Django default user

### DIFF
--- a/booksbridge/src/containers/Signin.js
+++ b/booksbridge/src/containers/Signin.js
@@ -3,11 +3,12 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import './containers.css';
 import Button from 'react-bootstrap/Button';
-import Form from 'react-bootstrap/Form'
+import Form from 'react-bootstrap/Form';
+import * as actionCreators from "../store/actions/index";
 
 class Signin extends Component {
   state = {
-    email: '',
+    username: '',
     password: '',
   }
 
@@ -32,31 +33,41 @@ class Signin extends Component {
     this.props.history.push('/main/');
   }
 
+  onClickSignInButton = (e) => {
+    const user = { "username": this.state.username, "password": this.state.password };
+    e.preventDefault();
+    this.props.onLoginUser(user);
+  };
+
   render() {
     return (
       <div className='login_page'>
         <h1>Login</h1>
-        <Form className="login_form">
+        <Form className="login_form" onSubmit={this.onClickSignInButton}>
           <Form.Group>
-            <Form.Label>Email address</Form.Label>
+            <Form.Label>Username</Form.Label>
             <Form.Control
               type="text"
-              id="email-input"
-              value={this.state.email}
-              onChange={(event) => this.setState({ email: event.target.value })} />
+              id="username-input"
+              placeholder="Enter username"
+              value={this.state.username}
+              onChange={(event) => this.setState({ username: event.target.value })} 
+              required />
           </Form.Group>
           <Form.Group>
             <Form.Label>Password</Form.Label>
             <Form.Control
               type="password"
               id="pw-input"
+              placeholder="Enter password"
               value={this.state.password}
-              onChange={(event) => this.setState({ password: event.target.value })} />
+              onChange={(event) => this.setState({ password: event.target.value })}
+              required />
           </Form.Group>
           <Button
             variant="primary"
             id="login-button"
-            onClick={() => this.LoginHandler()}>Sign in</Button>
+            type="submit">Sign in</Button>
           <Button
             variant="primary"
             id="signup-button"
@@ -74,7 +85,10 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
+    onLoginUser: (user) => {
+    dispatch(actionCreators.loginUser(user));
   }
+  };
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(Signin));

--- a/booksbridge/src/containers/Signup.js
+++ b/booksbridge/src/containers/Signup.js
@@ -20,25 +20,30 @@ class Signup extends Component {
     return nextState;
   }
 
-  onClickSignUpButton = () => {
+  onClickSignUpButton = (e) => {
     const user = { "email": this.state.email, "username": this.state.username, "password": this.state.password };
+    e.preventDefault();
     this.props.onAddUser(user);
-    this.props.history.push('/main');
+    this.props.history.push('/sign-in');
   };
 
   render() {
     return (
       <div className="login_page">
         <h1>Sign up</h1>
-        <Form className="login_form">
+        <Form className="login_form" onSubmit={this.onClickSignUpButton}>
           <Form.Group controlId="formBasicEmail">
             <Form.Label>Email address</Form.Label>
             <Form.Control
               type="email"
               placeholder="Enter email"
               value={this.state.email}
-              onChange={event => this.setState({ email: event.target.value })}
-            />
+              onChange={event => this.setState({ email: event.target.value })
+              }
+            required />
+            <Form.Control.Feedback type="invalid">
+            Please provide a valid email.
+            </Form.Control.Feedback>
           </Form.Group>
           <Form.Group controlId="validationFormikUsername">
             <Form.Label>Username</Form.Label>
@@ -50,7 +55,7 @@ class Signup extends Component {
               onChange={event =>
                 this.setState({ username: event.target.value })
               }
-            />
+              required />
             </Form.Group>
           <Form.Group controlId="formBasicPassword">
             <Form.Label>Password</Form.Label>
@@ -61,13 +66,12 @@ class Signup extends Component {
               onChange={event =>
                 this.setState({ password: event.target.value })
               }
-            />
+            required/>
           </Form.Group>
             <Button
               variant="primary"
               type="submit"
               id="login-button"
-              onClick={() => this.onClickSignUpButton()}
             >
               Confirm
           </Button>

--- a/booksbridge/src/containers/Signup.js
+++ b/booksbridge/src/containers/Signup.js
@@ -5,21 +5,25 @@ import * as actionCreators from "../store/actions/index";
 import "./containers.css";
 import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
+import FormCheck from 'react-bootstrap/FormCheck'
 
 class Signup extends Component {
   state = {
     email: "",
-    password: ""
+    password: "",
+    username: ""
   };
 
-  componentDidMount() {}
+  componentDidMount() { }
 
   static getDerivedStateFromProps(nextProps, nextState) {
     return nextState;
   }
 
   onClickSignUpButton = () => {
-    this.props.onAddUser(this.state.email, this.state.password);
+    const user = { "email": this.state.email, "username": this.state.username, "password": this.state.password };
+    this.props.onAddUser(user);
+    this.props.history.push('/main');
   };
 
   render() {
@@ -27,52 +31,65 @@ class Signup extends Component {
       <div className="login_page">
         <h1>Sign up</h1>
         <Form className="login_form">
-          <Form.Group>
+          <Form.Group controlId="formBasicEmail">
             <Form.Label>Email address</Form.Label>
             <Form.Control
-              type="text"
-              id="email-input"
+              type="email"
+              placeholder="Enter email"
               value={this.state.email}
               onChange={event => this.setState({ email: event.target.value })}
             />
           </Form.Group>
-          <Form.Group>
+          <Form.Group controlId="validationFormikUsername">
+            <Form.Label>Username</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder="Enter username"
+              aria-describedby="inputGroupPrepend"
+              value={this.state.username}
+              onChange={event =>
+                this.setState({ username: event.target.value })
+              }
+            />
+            </Form.Group>
+          <Form.Group controlId="formBasicPassword">
             <Form.Label>Password</Form.Label>
             <Form.Control
               type="password"
-              id="pw-input"
+              placeholder="Enter password"
               value={this.state.password}
               onChange={event =>
                 this.setState({ password: event.target.value })
               }
             />
           </Form.Group>
-          <Button
-            variant="primary"
-            id="login-button"
-            onClick={() => this.onClickSignUpButton()}
-          >
-            Confirm
+            <Button
+              variant="primary"
+              type="submit"
+              id="login-button"
+              onClick={() => this.onClickSignUpButton()}
+            >
+              Confirm
           </Button>
         </Form>
       </div>
-    );
-  }
-}
-
+        );
+      }
+    }
+    
 const mapStateToProps = state => {
   return {};
-};
-
+      };
+      
 const mapDispatchToProps = dispatch => {
   return {
-    onAddUser: (email, password) => {
-      //dispatch(actionCreators.postUser({email, password}));
-    }
+          onAddUser: (user) => {
+          dispatch(actionCreators.postUser(user));
+      }
+    };
   };
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Signup);
+  
+  export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(Signup);

--- a/booksbridge/src/containers/Signup.js
+++ b/booksbridge/src/containers/Signup.js
@@ -5,7 +5,6 @@ import * as actionCreators from "../store/actions/index";
 import "./containers.css";
 import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
-import FormCheck from 'react-bootstrap/FormCheck'
 
 class Signup extends Component {
   state = {
@@ -24,7 +23,6 @@ class Signup extends Component {
     const user = { "email": this.state.email, "username": this.state.username, "password": this.state.password };
     e.preventDefault();
     this.props.onAddUser(user);
-    this.props.history.push('/sign-in');
   };
 
   render() {

--- a/booksbridge/src/store/actions/actionCreators.js
+++ b/booksbridge/src/store/actions/actionCreators.js
@@ -1,9 +1,9 @@
 import * as actionTypes from './actionTypes';
 import axios from 'axios';
-import {push} from 'connected-react-router';
+import { push } from 'connected-react-router';
 
-axios.defaults.xsrfCookieName="csrftoken";
-axios.defaults.xsrfHeaderName="X-CSRFTOKEN";
+axios.defaults.xsrfCookieName = "csrftoken";
+axios.defaults.xsrfHeaderName = "X-CSRFTOKEN";
 
 // export const POST_NEW_USER = 'POST_NEW_USER'
 export const postUser = (user) => {
@@ -14,7 +14,7 @@ export const postUser = (user) => {
           type: actionTypes.POST_NEW_USER,
           user: res.data,
         });
-        dispatch(push('/sigin-in'));
+        dispatch(push('/sigin-in/'));
       })
   };
 };
@@ -22,13 +22,15 @@ export const postUser = (user) => {
 export const loginUser = (user) => {
   return dispatch => {
     return axios.post('/api/sign_in/', user)
-      .then(res =>{
+      .then(res => {
         dispatch({
           type: actionTypes.LOGIN_USER,
           user: res.data,
         });
-        //dispatch(push('/articles/'+res.data.id));
-    });
+        dispatch(push('/main/'));
+      }).catch(err => {
+        alert("Username or Password is incorrect.");
+      });
   };
 };
 

--- a/booksbridge/src/store/actions/actionCreators.js
+++ b/booksbridge/src/store/actions/actionCreators.js
@@ -2,6 +2,9 @@ import * as actionTypes from './actionTypes';
 import axios from 'axios';
 import push from 'connected-react-router';
 
+axios.defaults.xsrfCookieName="csrftoken";
+axios.defaults.xsrfHeaderName="X-CSRFTOKEN";
+
 // export const POST_NEW_USER = 'POST_NEW_USER'
 export const postUser = (user) => {
   return dispatch => {

--- a/booksbridge/src/store/actions/actionCreators.js
+++ b/booksbridge/src/store/actions/actionCreators.js
@@ -1,6 +1,6 @@
 import * as actionTypes from './actionTypes';
 import axios from 'axios';
-import push from 'connected-react-router';
+import {push} from 'connected-react-router';
 
 axios.defaults.xsrfCookieName="csrftoken";
 axios.defaults.xsrfHeaderName="X-CSRFTOKEN";
@@ -9,22 +9,29 @@ axios.defaults.xsrfHeaderName="X-CSRFTOKEN";
 export const postUser = (user) => {
   return dispatch => {
     return axios.post('/api/user/', user)
-      .then(res => dispatch({
-        type: actionTypes.POST_NEW_USER,
-        user: res.data,
-      }));
+      .then(res => {
+        dispatch({
+          type: actionTypes.POST_NEW_USER,
+          user: res.data,
+        });
+        dispatch(push('/sigin-in'));
+      })
   };
 };
 // export const LOGIN_USER = 'LOGIN_USER'
 export const loginUser = (user) => {
   return dispatch => {
     return axios.post('/api/sign_in/', user)
-      .then(res => dispatch({
-        type: actionTypes.LOGIN_USER,
-        user: res.data,
-      }));
+      .then(res =>{
+        dispatch({
+          type: actionTypes.LOGIN_USER,
+          user: res.data,
+        });
+        //dispatch(push('/articles/'+res.data.id));
+    });
   };
 };
+
 // export const LOGOUT_USER = 'LOGOUT_USER'
 export const logoutUser = () => {
   return dispatch => {

--- a/booksbridge_backend/book/urls.py
+++ b/booksbridge_backend/book/urls.py
@@ -3,7 +3,7 @@ from book import views
 
 urlpatterns = [
     path('user/', views.signup, name='signup'),
-    # path('sign_in/', views.signin, name='signin'),
+    path('sign_in/', views.signin, name='signin'),
     # path('sign_out/', views.signout, name='signout'),
     # path('book/', views.books, name='book'),
     path('book/<isbn>/', views.specific_book, name='specific_book'),

--- a/booksbridge_backend/book/urls.py
+++ b/booksbridge_backend/book/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from book import views
 
 urlpatterns = [
-    # path('user/', views.user, name='signup'),
+    path('user/', views.signup, name='signup'),
     # path('sign_in/', views.signin, name='signin'),
     # path('sign_out/', views.signout, name='signout'),
     # path('book/', views.books, name='book'),

--- a/booksbridge_backend/book/views.py
+++ b/booksbridge_backend/book/views.py
@@ -11,8 +11,9 @@ def signup(request):
     if request.method == 'POST':
         req_data = json.loads(request.body.decode())
         username = req_data['username']
+        email = req_data['email']
         password = req_data['password']
-        User.objects.create_user(username,'', password)
+        User.objects.create_user(username, email, password)
         return HttpResponse(status=201)
     else:
         return HttpResponseNotAllowed(['POST'])
@@ -101,6 +102,7 @@ def specific_book(request,isbn):
         return JsonResponse(book_dict,status=200)
     else:
         return HttpResponseNotAllowed(['GET'])
+
 @ensure_csrf_cookie
 def token(request):
     if request.method == 'GET':


### PR DESCRIPTION
Sign in, Sign up 페이지만 구현되어 있던 것 백엔드와 통신하게 수정했습니다.
중요한 것으로는 email, password만 있던 것을 username, email, password로 수정했습니다. username은 중복 불가능하며(지금은 중복체크 버튼이 없어서 클라이언트가 확인 불가능하지만, 중복된 username과 email 제출 시 500 에러 뜹니다.) 클라이언트는 username과 password로 로그인합니다.
그 외에 빈 칸이면 제출이 안되도록 처리했습니다. 공백 인풋(탭이나 스페이스)은 아직 처리하지 않았어요.