### PR TITLE
[BookDetail] fixed: clicking 'additional detail' in tabs doesnt work

### DIFF
--- a/booksbridge/src/components/BookDetail/BookTabsReviewList.js
+++ b/booksbridge/src/components/BookDetail/BookTabsReviewList.js
@@ -27,6 +27,7 @@ class BookTabsReviewList extends Component {
             is_long={review.is_long}
             is_short={review.is_short}
             is_phrase={review.is_phrase}
+            id={review.id}
           />
         </div>
       );


### PR DESCRIPTION
props로 id를 안넘겨주던 문제 해결했습니다.
Additional Details를 누르면 정상작동합니다